### PR TITLE
By using LinkedHashMap we ensure that when iterating the map, it will get the items in the same order that items were added (avoiding unit test error on RequestMapTest line 29 and line 39)

### DIFF
--- a/source/src/main/java/br/com/uol/pagseguro/api/utils/RequestMap.java
+++ b/source/src/main/java/br/com/uol/pagseguro/api/utils/RequestMap.java
@@ -26,7 +26,7 @@ import java.math.RoundingMode;
 import java.net.URLEncoder;
 import java.text.DateFormat;
 import java.util.Date;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import br.com.uol.pagseguro.api.common.domain.Config;
@@ -47,7 +47,7 @@ public final class RequestMap {
    * Constructor
    */
   public RequestMap() {
-    this(new HashMap<String, String>());
+    this(new LinkedHashMap<String, String>());
   }
 
   /**


### PR DESCRIPTION
By using LinkedHashMap we ensure that when iterating the map, it will get the items in the same order that items were added (avoiding unit test error on RequestMapTest line 29 and line 39)