### PR TITLE
Corrigindo valor MONTHS do enum Unit

### DIFF
--- a/source/src/main/java/br/com/uol/pagseguro/api/common/domain/enums/Unit.java
+++ b/source/src/main/java/br/com/uol/pagseguro/api/common/domain/enums/Unit.java
@@ -36,7 +36,7 @@ public enum Unit {
   /**
    * Months
    */
-  MONTHS ("MONTHS "),
+  MONTHS ("MONTHS"),
 
   /**
    * Years


### PR DESCRIPTION
Não é possível criar PreApprovals com expiration.unit = MONTHS pois o value está sendo enviado com um  espaço em branco no final.